### PR TITLE
Fix scavenger hunt delete bug

### DIFF
--- a/app/assets/javascripts/user_scavenger_hunts_index.js
+++ b/app/assets/javascripts/user_scavenger_hunts_index.js
@@ -1,4 +1,5 @@
 $(document).ready(() => {
+  setTimeout(clearFlashMessage, 2500);
   $(".delete-user-scavenger-hunt").unbind("click").on("click", deleteUserScavengerHunt);
 });
 

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -18,6 +18,11 @@
     font-weight: 500;
     text-align: center;
     color: white;
+
+    .flash-success {
+      font-size: 25px;
+      background-color: #768d87;
+    }
   }
 
   .flash-success {

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -18,7 +18,7 @@ class PointsController < ApplicationController
 
   private
 
-  def point_params
-    JSON.parse(request.body.to_json)[0]
-  end
+    def point_params
+      JSON.parse(request.body.to_json)[0]
+    end
 end

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -2,8 +2,7 @@ class PointsController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :authenticate!
 
-  def new
-  end
+  def new; end
 
   def create
     service = ScavengrBackend::ScavengerHunts.new(current_user)

--- a/app/controllers/scavenger_hunt_points_controller.rb
+++ b/app/controllers/scavenger_hunt_points_controller.rb
@@ -1,0 +1,6 @@
+class ScavengerHuntPointsController < ApplicationController
+  def destroy
+    DeletePointsJob.perform_later(params[:scavenger_hunt_id])
+    DeleteAllUserPointsJob.perform_later(params[:scavenger_hunt_id])
+  end
+end

--- a/app/controllers/scavenger_hunts_controller.rb
+++ b/app/controllers/scavenger_hunts_controller.rb
@@ -43,7 +43,7 @@ class ScavengerHuntsController < ApplicationController
     if response.status == 204
       DeletePointsJob.perform_later(params[:id])
       DeleteAllUserPointsJob.perform_later(params[:id])
-      flash[:success] = "Scavenger hunt deleted"
+      flash[:success] = "Successfully deleted scavenger hunt"
     else
       flash[:error] = "Failed to delete scavenger hunt"
     end

--- a/app/controllers/scavenger_hunts_controller.rb
+++ b/app/controllers/scavenger_hunts_controller.rb
@@ -38,8 +38,17 @@ class ScavengerHuntsController < ApplicationController
   end
 
   def destroy
-    DeletePointsJob.perform_later(params[:id])
-    DeleteAllUserPointsJob.perform_later(params[:id])
+    service = ScavengrBackend::ScavengerHunts.new(current_user)
+    response = service.destroy(params[:id])
+    require 'pry'; binding.pry
+    if response.status == 204
+      DeletePointsJob.perform_later(params[:id])
+      DeleteAllUserPointsJob.perform_later(params[:id])
+      flash[:success] = "Scavenger hunt deleted"
+    else
+      flash[:error] = "Failed to delete scavenger hunt"
+    end
+    redirect_to "/#{current_user.username}/scavenger_hunts"
   end
 
   private

--- a/app/controllers/scavenger_hunts_controller.rb
+++ b/app/controllers/scavenger_hunts_controller.rb
@@ -40,7 +40,6 @@ class ScavengerHuntsController < ApplicationController
   def destroy
     service = ScavengrBackend::ScavengerHunts.new(current_user)
     response = service.destroy(params[:id])
-    require 'pry'; binding.pry
     if response.status == 204
       DeletePointsJob.perform_later(params[:id])
       DeleteAllUserPointsJob.perform_later(params[:id])
@@ -53,7 +52,7 @@ class ScavengerHuntsController < ApplicationController
 
   private
 
-  def hunt_params
-    params.require(:scavenger_hunt).permit(:name, :description)
-  end
+    def hunt_params
+      params.require(:scavenger_hunt).permit(:name, :description)
+    end
 end

--- a/app/views/user_scavenger_hunts/index.html.erb
+++ b/app/views/user_scavenger_hunts/index.html.erb
@@ -16,7 +16,7 @@
       </a>
       <% if current_user.id == hunt.user_id %>
         <%= link_to '<i class="fas fa-edit"></i>'.html_safe, edit_scavenger_hunt_path(hunt.id), method: :get, class: 'edit-btn' %>
-        <%= link_to '<i class="fas fa-trash-alt"></i>'.html_safe, scavenger_hunt_path(hunt.id), method: :delete, class: 'delete-btn delete-user-scavenger-hunt', username: "#{current_user.username}", token: "#{current_user.token}", scavenger_hunt_id: "#{hunt.id}"%>
+        <%= link_to '<i class="fas fa-trash-alt"></i>'.html_safe, all_scavenger_hunt_points_path(hunt.id), method: :delete, class: 'delete-btn delete-user-scavenger-hunt', username: "#{current_user.username}", token: "#{current_user.token}", scavenger_hunt_id: "#{hunt.id}"%>
       <% end %>
     </ul>
     <% end %>

--- a/app/views/user_scavenger_hunts/index.html.erb
+++ b/app/views/user_scavenger_hunts/index.html.erb
@@ -4,7 +4,13 @@
        <%= "#{@username}'s Scavenger Hunts" %>
      </div>
   </nav>
-  <div class="flash-message"></div>
+  <div class="flash-message">
+    <% flash.each do |key, value| %>
+      <div class="flash-<%= key %>">
+        <%= value %>
+      </div>
+    <% end %>
+  </div>
   <div class='cards-container'>
     <% @scavenger_hunts.each do |hunt| %>
     <ul class='scavenger-hunt-card'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   resources :current_scavenger_hunts, only: %i[index destroy]
 
   resources :scavenger_hunts do
-    resources :points, only: %i[new create update]
+    resources :points, only: %i[new create update destroy]
   end
 
   resources :user_points, only: %i[update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,10 @@ Rails.application.routes.draw do
   resources :current_scavenger_hunts, only: %i[index destroy]
 
   resources :scavenger_hunts do
-    resources :points, only: %i[new create update destroy]
+    resources :points, only: %i[new create update]
   end
+
+  delete '/scavenger_hunt_points/:scavenger_hunt_id', to: 'scavenger_hunt_points#destroy', as: 'all_scavenger_hunt_points'
 
   resources :user_points, only: %i[update]
 


### PR DESCRIPTION
#### Pivotal URL: https://www.pivotaltracker.com/n/projects/2185238

#### Proposed Feature: Fix scavenger hunt delete bug. User scavenger hunt show page delete button only deleted points.

###### Changes Made:
* Add ScavengerHuntPoints controller
* Point user scavenger hunt index delete button to ScavengerHuntPoints controller. Scavenger hunt record is deleted with fetch request, and the ScavengerHuntPointsController#destroy method now just queues the job to delete all point associated with that record.
* Update UserScavengerHuntController: re-build destroy method to delete scavenger hunt record and queue points deletion jobs.
* Add flash message div to index to display flash messages generated by Rails
* Add clearMessage() with a setTimeout of 2.5 seconds to user scavenger hunt index script to clear Rails flash messages similarly to how they are displayed and then cleared after fetch deletion
